### PR TITLE
Fix MonadUnliftIO docs

### DIFF
--- a/unliftio-core/src/Control/Monad/IO/Unlift.hs
+++ b/unliftio-core/src/Control/Monad/IO/Unlift.hs
@@ -35,20 +35,17 @@ newtype UnliftIO m = UnliftIO { unliftIO :: forall a. m a -> IO a }
 -- 'MonadUnliftIO' to 'ReaderT' and 'IdentityT' transformers on top of
 -- 'IO'.
 --
--- Laws. For any value @u@ returned by 'askUnliftIO', it must meet the
+-- Laws. For any function @run@ provided by 'withRunInIO', it must meet the
 -- monad transformer laws as reformulated for @MonadUnliftIO@:
 --
--- * @unliftIO u . return = return@
+-- * @run . return = return@
 --
--- * @unliftIO u (m >>= f) = unliftIO u m >>= unliftIO u . f@
+-- * @run (m >>= f) = run m >>= run . f@
 --
--- Instances of @MonadUnliftIO@ must also satisfy the idempotency law:
+-- Instances of @MonadUnliftIO@ must also satisfy the following laws:
 --
--- * @withRunInIO (\\run -> run m) = m@
---
--- This law showcases that 'withRunInIO' and @run@ are inverse operations.
--- @run@ will "lower" the @m@ action to 'IO', then 'withRunInIO' will "lift"
--- it back up to @m@, with no changes to the monadic context.
+-- [Identity law] @withRunInIO (\\run -> run m) = m@
+-- [Inverse law]  @withRunInIO (\\_ -> m) = liftIO m@
 --
 -- As an example of an invalid instance, a naive implementation of
 -- @MonadUnliftIO (StateT s m)@ might be
@@ -60,7 +57,7 @@ newtype UnliftIO m = UnliftIO { unliftIO :: forall a. m a -> IO a }
 --       inner (run . flip evalStateT s)
 -- @
 --
--- This breaks the idempotency law because the inner @run m@ would throw away
+-- This breaks the identity law because the inner @run m@ would throw away
 -- any state changes in @m@.
 --
 -- @since 0.1.0.0

--- a/unliftio-core/src/Control/Monad/IO/Unlift.hs
+++ b/unliftio-core/src/Control/Monad/IO/Unlift.hs
@@ -44,11 +44,24 @@ newtype UnliftIO m = UnliftIO { unliftIO :: forall a. m a -> IO a }
 --
 -- Instances of @MonadUnliftIO@ must also satisfy the idempotency law:
 --
--- * @withRunInIO (\\run -> (liftIO . run) m) = m@
+-- * @withRunInIO (\\run -> run m) = m@
 --
--- This law showcases two properties. First, 'withRunInIO' doesn't change
--- the monadic context, and second, @liftIO . run@ is equivalent to
--- @id@ IF called in the same monadic context as 'withRunInIO'.
+-- This law showcases that 'withRunInIO' and @run@ are inverse operations.
+-- @run@ will "lower" the @m@ action to 'IO', then 'withRunInIO' will "lift"
+-- it back up to @m@, with no changes to the monadic context.
+--
+-- As an example of an invalid instance, a naive implementation of
+-- @MonadUnliftIO (StateT s m)@ might be
+--
+-- @
+-- withRunInIO inner =
+--   StateT $ \\s ->
+--     withRunInIO $ \\run ->
+--       inner (run . flip evalStateT s)
+-- @
+--
+-- This breaks the idempotency law because the inner @run m@ would throw away
+-- any state changes in @m@.
 --
 -- @since 0.1.0.0
 class MonadIO m => MonadUnliftIO m where


### PR DESCRIPTION
The old docs were written in the context of `askUnliftIO`, but it doesn't make sense with `withRunInIO`. e.g. the "if called in the same monadic context" qualifier made sense with `askUnliftIO`, to prevent the case of a user returning the `UnliftIO` and using it elsewhere, but `withRunInIO` forces its usage within the given callback.

I also took the liberty of adding an example bad instance, to further illustrate the law. Happy to revert if desired